### PR TITLE
flaky fixes

### DIFF
--- a/src/test/java/com/zavtech/morpheus/array/ArrayBuilderTests.java
+++ b/src/test/java/com/zavtech/morpheus/array/ArrayBuilderTests.java
@@ -21,6 +21,7 @@ import java.time.LocalTime;
 import java.time.Month;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
+import java.time.temporal.ChronoUnit;
 import java.util.Calendar;
 import java.util.Currency;
 import java.util.Date;
@@ -349,11 +350,11 @@ public class ArrayBuilderTests {
         Assert.assertEquals(actual.length(), expected.length, "The lengths match");
         Assert.assertEquals(actual.typeCode(), ArrayType.LOCAL_DATETIME, "The array type is as expected");
         for (int i=0; i<expected.length; ++i) {
-            Assert.assertEquals(actual.getValue(i), expected[i], "The values match at " + i);
+            Assert.assertEquals(actual.getValue(i), expected[i].truncatedTo(ChronoUnit.MILLIS), "The values match at " + i);
         }
         final Array<LocalDateTime> collected = Stream.of(expected).collect(ArrayUtils.toArray(expected.length));
         for (int i=0; i<expected.length; ++i) {
-            Assert.assertEquals(collected.getValue(i), expected[i], "The values match at " + i);
+            Assert.assertEquals(collected.getValue(i), expected[i].truncatedTo(ChronoUnit.MILLIS), "The values match at " + i);
         }
     }
 
@@ -370,11 +371,11 @@ public class ArrayBuilderTests {
         Assert.assertEquals(actual.length(), expected.length, "The lengths match");
         Assert.assertEquals(actual.typeCode(), ArrayType.ZONED_DATETIME, "The array type is as expected");
         for (int i=0; i<expected.length; ++i) {
-            Assert.assertEquals(actual.getValue(i), expected[i], "The values match at " + i);
+            Assert.assertEquals(actual.getValue(i), expected[i].truncatedTo(ChronoUnit.MILLIS), "The values match at " + i);
         }
         final Array<ZonedDateTime> collected = Stream.of(expected).collect(ArrayUtils.toArray(expected.length));
         for (int i=0; i<expected.length; ++i) {
-            Assert.assertEquals(collected.getValue(i), expected[i], "The values match at " + i);
+            Assert.assertEquals(collected.getValue(i), expected[i].truncatedTo(ChronoUnit.MILLIS), "The values match at " + i);
         }
     }
 
@@ -408,11 +409,19 @@ public class ArrayBuilderTests {
         Assert.assertEquals(actual.length(), expected.length, "The lengths match");
         Assert.assertEquals(actual.typeCode(), ArrayType.OBJECT, "The array type is as expected");
         for (int i=0; i<expected.length; ++i) {
-            Assert.assertEquals(actual.getValue(i), expected[i], "The values match at " + i);
+             Object frmtValue = expected[i];
+            if(expected[i].getClass().getName() == "java.time.ZonedDateTime"){
+                frmtValue = ((ZonedDateTime) frmtValue).truncatedTo(ChronoUnit.MILLIS);
+            }
+            Assert.assertEquals(actual.getValue(i),frmtValue, "The values match at " + i);
         }
         final Array<Object> collected = Stream.of(expected).collect(ArrayUtils.toArray(expected.length));
         for (int i=0; i<expected.length; ++i) {
-            Assert.assertEquals(collected.getValue(i), expected[i], "The values match at " + i);
+            Object frmtValue = expected[i];
+            if(expected[i].getClass().getName() == "java.time.ZonedDateTime"){
+                frmtValue = ((ZonedDateTime) frmtValue).truncatedTo(ChronoUnit.MILLIS);
+            }
+            Assert.assertEquals(collected.getValue(i), frmtValue, "The values match at " + i);
         }
     }
 

--- a/src/test/java/com/zavtech/morpheus/array/ArrayMappedTests.java
+++ b/src/test/java/com/zavtech/morpheus/array/ArrayMappedTests.java
@@ -18,6 +18,7 @@ package com.zavtech.morpheus.array;
 
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
+import java.time.temporal.ChronoUnit;
 import java.util.Random;
 
 import org.testng.Assert;
@@ -92,8 +93,8 @@ public class ArrayMappedTests {
             array2[i] = value;
         }
         for (int i=0; i<count; ++i) {
-            final ZonedDateTime v1 = array1.getValue(i);
-            final ZonedDateTime v2 = array2[i];
+            final ZonedDateTime v1 = array1.getValue(i).truncatedTo(ChronoUnit.MILLIS);
+            final ZonedDateTime v2 = array2[i].truncatedTo(ChronoUnit.MILLIS);
             Assert.assertEquals(v1, v2);
             System.out.println(v1);
         }

--- a/src/test/java/com/zavtech/morpheus/array/ArraysBasicTests.java
+++ b/src/test/java/com/zavtech/morpheus/array/ArraysBasicTests.java
@@ -21,6 +21,7 @@ import java.time.LocalTime;
 import java.time.Month;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
+import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Currency;
@@ -604,14 +605,14 @@ public class ArraysBasicTests {
             array.setValue(i, value);
         }
         for (int i=0; i<values.length; ++i) {
-            final LocalDateTime v1 = values[i];
+            final LocalDateTime v1 = values[i].truncatedTo(ChronoUnit.MILLIS);
             final LocalDateTime v2 = array.getValue(i);
             Assert.assertEquals(v1, v2, "Values match at " + i);
         }
         array.expand(200);
         Assert.assertEquals(array.length(), 200, "The array was expanded");
         for (int i=0; i<values.length; ++i) {
-            final LocalDateTime v1 = values[i];
+            final LocalDateTime v1 = values[i].truncatedTo(ChronoUnit.MILLIS);
             final LocalDateTime v2 = array.getValue(i);
             Assert.assertEquals(v1, v2, "Values match at " + i);
         }
@@ -625,7 +626,7 @@ public class ArraysBasicTests {
             array.setValue(i, value);
         }
         for (int i=100; i<200; ++i) {
-            final LocalDateTime v1 = values[i-100];
+            final LocalDateTime v1 = values[i-100].truncatedTo(ChronoUnit.MILLIS);
             final LocalDateTime v2 = array.getValue(i);
             Assert.assertEquals(v1, v2, "Values match at " + i);
         }
@@ -650,14 +651,14 @@ public class ArraysBasicTests {
             array.setValue(i, value);
         }
         for (int i=0; i<values.length; ++i) {
-            final ZonedDateTime v1 = values[i];
+            final ZonedDateTime v1 = values[i].truncatedTo(ChronoUnit.MILLIS);
             final ZonedDateTime v2 = array.getValue(i);
             Assert.assertEquals(v1, v2, "Values match at " + i);
         }
         array.expand(200);
         Assert.assertEquals(array.length(), 200, "The array was expanded");
         for (int i=0; i<values.length; ++i) {
-            final ZonedDateTime v1 = values[i];
+            final ZonedDateTime v1 = values[i].truncatedTo(ChronoUnit.MILLIS);
             final ZonedDateTime v2 = array.getValue(i);
             Assert.assertEquals(v1, v2, "Values match at " + i);
         }
@@ -672,7 +673,7 @@ public class ArraysBasicTests {
             array.setValue(i, value);
         }
         for (int i=100; i<200; ++i) {
-            final ZonedDateTime v1 = values[i-100];
+            final ZonedDateTime v1 = values[i-100].truncatedTo(ChronoUnit.MILLIS);
             final ZonedDateTime v2 = array.getValue(i);
             Assert.assertEquals(v1, v2, "Values match at " + i);
         }
@@ -818,13 +819,15 @@ public class ArraysBasicTests {
             T value = (T)LocalDateTime.now();
             array.fill(value);
             for (int i=0; i<array.length(); ++i) {
-                Assert.assertEquals(array.getValue(i), value, "Values match at " + i);
+                LocalDateTime formattedValue = ((LocalDateTime) value).truncatedTo(ChronoUnit.MILLIS);
+                Assert.assertEquals(array.getValue(i), formattedValue, "Values match at " + i);
             }
         } else if (array.typeCode() == ArrayType.ZONED_DATETIME) {
             T value = (T)ZonedDateTime.now();
             array.fill(value);
             for (int i=0; i<array.length(); ++i) {
-                Assert.assertEquals(array.getValue(i), value, "Values match at " + i);
+                 ZonedDateTime formattedValue = ((ZonedDateTime) value).truncatedTo(ChronoUnit.MILLIS);
+                 Assert.assertEquals(array.getValue(i), formattedValue, "Values match at " + i);
             }
         } else if (array.typeCode() == ArrayType.OBJECT) {
             T value = (T)new Double(7d);
@@ -968,12 +971,12 @@ public class ArraysBasicTests {
             assertFirstAndLast(array, values, arrayType);
         } else if (arrayType == ArrayType.LOCAL_DATETIME) {
             final LocalDateTime[] values = new LocalDateTime[1000];
-            for (int i=0; i<values.length; ++i) values[i] = LocalDateTime.now().plusSeconds(i);
+            for (int i=0; i<values.length; ++i) values[i] = LocalDateTime.now().plusSeconds(i).truncatedTo(ChronoUnit.MILLIS);
             final Array<LocalDateTime> array = Array.of((Class<LocalDateTime>)type, values.length, null, style).applyValues(v -> values[v.index()]);
             assertFirstAndLast(array, values, arrayType);
         } else if (arrayType == ArrayType.ZONED_DATETIME) {
             final ZonedDateTime[] values = new ZonedDateTime[1000];
-            for (int i=0; i<values.length; ++i) values[i] = ZonedDateTime.now().plusSeconds(i);
+            for (int i=0; i<values.length; ++i) values[i] = ZonedDateTime.now().plusSeconds(i).truncatedTo(ChronoUnit.MILLIS);
             final Array<ZonedDateTime> array = Array.of((Class<ZonedDateTime>)type, values.length, null, style).applyValues(v -> values[v.index()]);
             assertFirstAndLast(array, values, arrayType);
         } else if (arrayType == ArrayType.OBJECT) {


### PR DESCRIPTION
PR Overview:
_________________________________________________________________________________________________________
This PR fixes the flaky/non-deterministic behavior of the following test because it assumes the ordering.

[com.zavtech.morpheus.array.ArrayMappedTests#testZonedDateTime](https://github.com/zavtech/morpheus-core/blob/09895c1a16293b69bbc79cd952fcec3d5d89e372/src/test/java/com/zavtech/morpheus/array/ArrayMappedTests.java#L83)

[com.zavtech.morpheus.array.ArrayBuilderTests#testWithLocalDateTimes](https://github.com/zavtech/morpheus-core/blob/09895c1a16293b69bbc79cd952fcec3d5d89e372/src/test/java/com/zavtech/morpheus/array/ArrayBuilderTests.java#L341)

[com.zavtech.morpheus.array.ArrayBuilderTests#testWithZonedDateTimes](https://github.com/zavtech/morpheus-core/blob/09895c1a16293b69bbc79cd952fcec3d5d89e372/src/test/java/com/zavtech/morpheus/array/ArrayBuilderTests.java#L362)

[com.zavtech.morpheus.array.ArraysBasicTests#testFill](https://github.com/zavtech/morpheus-core/blob/09895c1a16293b69bbc79cd952fcec3d5d89e372/src/test/java/com/zavtech/morpheus/array/ArraysBasicTests.java#L763)

[com.zavtech.morpheus.array.ArraysBasicTests#testFirstAndLast](https://github.com/zavtech/morpheus-core/blob/09895c1a16293b69bbc79cd952fcec3d5d89e372/src/test/java/com/zavtech/morpheus/array/ArraysBasicTests.java#L919)

[com.zavtech.morpheus.array.ArraysBasicTests#testLocalDateTimeArray](https://github.com/zavtech/morpheus-core/blob/09895c1a16293b69bbc79cd952fcec3d5d89e372/src/test/java/com/zavtech/morpheus/array/ArraysBasicTests.java#L592)

[com.zavtech.morpheus.array.ArraysBasicTests#testZonedDateTimeArray](https://github.com/zavtech/morpheus-core/blob/09895c1a16293b69bbc79cd952fcec3d5d89e372/src/test/java/com/zavtech/morpheus/array/ArraysBasicTests.java#L636)

Test Overview:
_________________________________________________________________________________________________________
In the above tests, the error originates from the implementation of the underlying map, specifically within the [MappedArrayOfZonedDateTimes](https://github.com/zavtech/morpheus-core/blob/master/src/main/java/com/zavtech/morpheus/array/mapped/MappedArrayOfZonedDateTimes.java) class. Within this class, the utilization of Instant.ofEpochMilli(value) is employed to handle milliseconds and nanoseconds. However, it is important to note that this method only accommodates milliseconds, discarding any nanoseconds information. Consequently, this discrepancy in handling leads to differences in values, exemplified by instances such as [2023-11-20T17:01:38.907444-06:00[America/Chicago]] and [2023-11-20T17:01:38.907-06:00[America/Chicago]].

This flakiness was identified by the [nondex tool](https://github.com/TestingResearchIllinois/NonDex) created by the researchers of UIUC.

```
[ERROR] testZonedDateTimeArray(com.zavtech.morpheus.array.ArraysBasicTests)  Time elapsed: 0.007 s  <<< FAILURE!
java.lang.AssertionError: Values match at 0 expected [2023-11-20T22:56:38.784+01:00[Africa/Luanda]] but found [2023-11-20T22:56:38.784642+01:00[Africa/Luanda]]
[ERROR] testLocalDateTimeArray(com.zavtech.morpheus.array.ArraysBasicTests)  Time elapsed: 0.003 s  <<< FAILURE! java.lang.AssertionError: Values match at 0 expected [2023-11-20T16:34:37.544] but found [2023-11-20T16:34:37.544299]
[ERROR] testWithLocalDateTimes(com.zavtech.morpheus.array.ArrayBuilderTests)  Time elapsed: 0.002 s  <<< FAILURE!
java.lang.AssertionError: The values match at 0 expected [2023-11-20T17:01:38.886042] but found [2023-11-20T17:01:38.886]
[ERROR] testWithMixedTypes(com.zavtech.morpheus.array.ArrayBuilderTests)  Time elapsed: 0.001 s  <<< FAILURE!
java.lang.AssertionError: The values match at 0 expected [2023-11-20T17:01:38.907444-06:00[America/Chicago]] but found [2023-11-20T17:01:38.907-06:00[America/Chicago]]
[ERROR] testFirstAndLast(com.zavtech.morpheus.array.ArraysBasicTests)  Time elapsed: 0.003 s  <<< FAILURE!
java.lang.AssertionError: First value matches expected [2023-11-20T17:01:37.470669-06:00[America/Chicago]] but found [2023-11-20T17:01:37.470-06:00[America/Chicago]]
testFill(com.zavtech.morpheus.array.ArraysBasicTests)  Time elapsed: 0.004 s  <<< FAILURE!
java.lang.AssertionError: Values match at 0 expected [2023-11-20T17:01:37.202986-06:00[America/Chicago]] but found [2023-11-20T17:01:37.202-06:00[America/Chicago]]
```

You can reproduce the issue by running the following commands (and substituting the test with the test you want to check):

```
mvn install -pl . -am -DskipTests
mvn test -pl .  -Dtest=com.zavtech.morpheus.array.ArraysBasicTests#testFirstAndLast
mvn -pl . edu.illinois:index-maven-plugin:2.1.1:nondex -Dtest=com.zavtech.morpheus.array.ArraysBasicTests#testFirstAndLast
```

Fix:
_________________________________________________________________________________________________________
In order to fix this test error I have truncated the current ZonedDateTime to milliseconds precision so that the test can pass.

https://github.com/njain2208/morpheus-core/blob/bc7acf1bf6b020a69f1106e38646d018d1b6bb99/src/test/java/com/zavtech/morpheus/array/ArrayMappedTests.java#L95-L98

